### PR TITLE
Add in QRCode Quickchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [QR Google Charts](https://aiaraldea.github.io/qr-google-charts/) - Another QR Code plugin, using Google Charts API.
 - [QRCode](https://github.com/seandrickson/YOURLS-QRCode-Plugin) - Another QR Code plugin. Get the QR code by simply clicking on a button in the Admin area (or by adding ".qr" to the end of the keyword).
 - [QRCode Local](https://github.com/alexkolodko/yourls-local-qr-code) — Add ".qr" to short URLs to display the shorturl's QR code in SVG, PDF, PNG or JPG (local generation with JS).
+- [QRCode Quickchart](https://github.com/tyler71/yourls-quickchart-qr-code)  — QR Code plugin, using [Quickchart](https://quickchart.io/). Combatible with a self-hosted Quickchart instance. Default suffix `/qr`.
 - [QueryString Forward](https://github.com/llonchj/yourls_plugins) - Forward the query string on short link to long URL (eg `http://sho.rt/kk?a=1` to `http://long.url/somepage/?a=1`).
 - [Query String Keeper](https://github.com/jessemaps/yourls-query-string-keeper) - Pass the query string from the shortlink to the long URL (eg `http://sho.rt/kk?hey` forwards to `http://long.url/bleh/?hey`).
 - [Query String Keeper](https://github.com/littleskyfish/query-string-keeper) - Pass the query string from the shortlink to the long URL (tested on YOURLS version 1.8.3 and php version 8.0.12).


### PR DESCRIPTION
This is for generating qr codes for short urls using Quickchart. Allows using a self hosted Quickchart instance, defaulting to the main instance.