### PR TITLE
Add Domain Allowlist + Alerts plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [Device Details](https://github.com/SachinSAgrawal/YOURLS-Device-Details) - Display click details, including IP, user-agent, device information, and more.
 - [Device Charts](https://github.com/AlbertoVargasMoreno/YOURLS-Device-Charts) - Display charts showcasing information about browsers, platforms, and devices used by visitors.
 - [Disable JSONP](https://github.com/seandrickson/YOURLS-Disable-JSONP) - Disables JSONP access for the YOURLS API.
+- [Domain Allowlist + Alerts](https://github.com/seventhsite/yourls-domain-allowlist) - Restrict shortening to an allowlist of domains, with an admin page (one-click-allow rejected domains) and throttled Telegram alerts. No extra DB table, no cron.
 - [Domain Limit](https://github.com/nicwaller/yourls-domainlimit-plugin) - Limit the domains that users can create shortlinks to.
 - [Domain Limiter](https://bitbucket.org/quantumwebco/domain-limiter-yourls-plugin) - Fork of Nic Waller's plugin with the addition of an admin panel to edit the white list from the admin area.
 - [Do TLS](https://github.com/joshp23/YOURLS-doTLS) - Always use SSL/TLS for a destination url if available.


### PR DESCRIPTION
Adds [Domain Allowlist + Alerts](https://github.com/seventhsite/yourls-domain-allowlist) to the **Plugins → D** section (placed alphabetically, before `Domain Limit`).

### What it does
Restricts URL shortening to an allowlist of domains (exact host or any subdomain), with:
- an **admin settings page** with **one-click "Add to allowlist"** straight from the live list of rejected attempts,
- optional **throttled Telegram alerts** (instant + periodic digest) about rejected domains, with per-domain cooldown and a global send gap so it can't spam or get the bot banned,
- **no extra DB table and no cron** — stats live in a single size-bounded JSON file and the digest piggybacks on normal traffic ("lazy cron").

### How it relates to the two existing entries
This is **additive, not a duplicate**:
- **Domain Limit** (`nicwaller/yourls-domainlimit`) — config-file only; no UI to manage the list, and no visibility into what was rejected.
- **Domain Limiter** (`quantumwebco` fork) — adds an admin panel to edit the whitelist, but nothing beyond editing it.
- **Domain Allowlist + Alerts** is **drop-in compatible** with `nicwaller/yourls-domainlimit` (it reuses `$domainlimit_list` and `$domainlimit_exempt_users`, so existing installs switch with no config changes) and adds the rejected-domain feedback loop on top: see what users actually tried to shorten, allow it in one click, and optionally get notified — all without an extra DB table or cron.

GPLv2, PHP 8.x clean, no external dependencies.

### Checklist
- [x] Entry added alphabetically within its letter section
- [x] Followed the existing `- [Name](url) - Description.` format
- [x] Plugin count left untouched (auto-updated by the bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)