### PR TITLE
Override global PR template with one just for awesome

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Pre-requisites
+
+- [ ] I have read the [Contributing Guidelines](https://github.com/YOURLS/awesome/blob/main/CONTRIBUTING.md)
+- [ ] The link(s) I am adding point to my own work
+
+
+## Project Description(s)
+<!--- Describe IN YOUR OWN WORDS what your plugin(s) do.
+      If there is a visual component (admin page, public UI, etc.) please show it or link to a demo. --->
+


### PR DESCRIPTION
## Pre-requisites

- [x] I have read the [Contributing Guidelines](https://github.com/YOURLS/.github/blob/main/CONTRIBUTING.md)

## Change Description
Follow-up to https://github.com/YOURLS/.github/pull/79#issuecomment-5303489266 — giving Awesome its own PR template that's less focused on code contributions.

This will override the one from `YOURLS/.github` once merged.