### PR TITLE
Add YOURLS-RBAC to Plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [YAPCache](https://github.com/tipichris/YAPCache) - YAPCache is an APC based cache designed to reduce the database load of YOURLS and increase performance.
 - [YOURS-TN](https://github.com/sgiovagnoli/YOURLS-TN) - Display thumbnails on YOURLS admin page and stats page, using thumbnail.ws.
 - [YouTube Title Fix](https://github.com/joshp23/YOURLS-YouTube-title-fix) - Fetch YouTube page titles via Google API.
+- [YOURLS-RBAC](https://github.com/saahmadnejad/YOURLS-RBAC) - Role-Based Access Control: database-backed users, roles and permissions with a full admin UI, replacing the single-user `config.php` login.
 
 [⬆️ Go to section](#plugins)
 


### PR DESCRIPTION
Adds [YOURLS-RBAC](https://github.com/saahmadnejad/YOURLS-RBAC) to the Plugins section (alphabetical, under Y).

YOURLS-RBAC brings Role-Based Access Control to YOURLS: database-backed users, roles and granular permissions, managed from a built-in admin UI — instead of the single-user `config.php` login. Permission checks gate core admin pages, AJAX actions, the API and plugin (de)activation. Existing `config.php` users keep working alongside database users.

- Free and open source (MIT)
- Hosted on GitHub with issue tracker for user interaction, as per CONTRIBUTING.md

Checklist:
- [x] Link points to a working repo users can interact with
- [x] Entry follows existing list format (one line, name + short description)
- [x] Plugin count markers left untouched (auto-updated)