### PR TITLE
Add Farsi (fa_IR) translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ YOURLS supports localization: this means if a language file for YOURLS in availa
 - [Danish](https://github.com/jensz12/YOURLSDK) (`da_DK`)
 - [Dutch](https://github.com/toineenzo/YOURLS-nl_NL) (`nl_NL`)
 - [English (Australian)](https://github.com/bakkbone/yourls-en_AU) (`en_AU`)
+- [Farsi](https://github.com/saahmadnejad/YOURLS-fa_IR) (`fa_IR`)
 - [Finnish](https://github.com/re2man/YOURLS-fi_FI) (`fi_FI`)
 - [French](https://github.com/ozh/YOURLS-fr_FR) (`fr_FR`)
 - [German](https://github.com/DerSev/YOURLS-de_DE) (`de_DE`)


### PR DESCRIPTION
Adds a complete Farsi (فارسی) translation of YOURLS to the Translations section.

**Repo:** [saahmadnejad/YOURLS-fa_IR](https://github.com/saahmadnejad/YOURLS-fa_IR)

- All 307 strings translated, built from the official [YOURLS.pot](https://github.com/YOURLS/YOURLS.pot) (1.10.3 template)
- Full RTL support: includes the `text direction` context string (`ltr` → `rtl`), so YOURLS renders the admin interface with `dir="rtl"` — the first RTL translation listed
- Farsi number formatting (thousands sep `٬`, decimal point `٫`), translated calendar (weekdays/months with the `_initial`/`_abbreviation` suffix hacks preserved)
- `fa_IR.po` + compiled `fa_IR.mo` clearly labelled in the repo; usage instructions in the README
- Tested against a live YOURLS install: login, dashboard, plugins page, list/search, error pages all render in Farsi with RTL layout

```
define( 'YOURLS_LANG', 'fa_IR' );
``