### PR TITLE
Add Tracking Pro plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [Time-Period Clicks](https://github.com/rinogo/yourls-time-period-clicks) - A simple API plugin for reporting URL clicks in a specific time period (e.g. the last week, January 1 - February 1, etc).
 - [Time Limit Link](https://github.com/chesterrush/yourls-Time-Limit-Link) - Set a time limit for links.
 - [Track Custom Keyword](https://github.com/timcrockford/track-custom-keywords) - Add a new field to YOURLS designed to track if a keyword was randomly assigned or manually specified.
-- [Tracking Pro](https://github.com/johnatanmoran/yourls-tracking-pro) - Extended click analytics with device, browser, language and UTM campaign data, bot filtering, and downloadable CSV, JSON and PDF reports.
+- [Tracking Pro](https://github.com/johnatanmoran/yourls-tracking-pro) - Extended click analytics with device, browser, language and UTM campaign data, bot filtering, and downloadable CSV, JSON and PDF reports. Interface available in Spanish (default) and English.
 - [Typer, a yourls prank plugin](https://github.com/koma5/typer) - Add an underscore * to your shortlink and the user will be shown a page where they have to type the shortlink themselves.
 
 [⬆️ Go to section](#plugins)

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [Time-Period Clicks](https://github.com/rinogo/yourls-time-period-clicks) - A simple API plugin for reporting URL clicks in a specific time period (e.g. the last week, January 1 - February 1, etc).
 - [Time Limit Link](https://github.com/chesterrush/yourls-Time-Limit-Link) - Set a time limit for links.
 - [Track Custom Keyword](https://github.com/timcrockford/track-custom-keywords) - Add a new field to YOURLS designed to track if a keyword was randomly assigned or manually specified.
+- [Tracking Pro](https://github.com/johnatanmoran/yourls-tracking-pro) - Extended click analytics with device, browser, language and UTM campaign data, bot filtering, and downloadable CSV, JSON and PDF reports.
 - [Typer, a yourls prank plugin](https://github.com/koma5/typer) - Add an underscore * to your shortlink and the user will be shown a page where they have to type the shortlink themselves.
 
 [⬆️ Go to section](#plugins)


### PR DESCRIPTION
Adds Tracking Pro under T in the plugins list.

- Repository: https://github.com/johnatanmoran/yourls-tracking-pro
- Free to use; original plugin code and documentation licensed under CC BY 4.0. Bundled PDF dependencies retain their own licenses.
- Captures device/browser/OS/language and UTM campaign data, with heuristic bot detection and filtered CSV, JSON and PDF downloads.
- The dashboard is Spanish by default and can be switched to English; the README documents both languages and includes screenshots of link selection and report results.
- Installation instructions and plugin-specific support are available in the repository and its GitHub Issues.
- Targets YOURLS 1.10.6+ and PHP 8.2+. Automated checks use API stubs and SQLite; integration testing against a live YOURLS/MySQL installation is still pending and documented.

Only one list entry was added; the automated plugin count was not changed. The "Listed in Awesome YOURLS" badge will be added to the plugin README after acceptance.